### PR TITLE
Fixed typo

### DIFF
--- a/Examples/UIExplorer/TouchableExample.js
+++ b/Examples/UIExplorer/TouchableExample.js
@@ -332,7 +332,7 @@ var TouchableDisabled = React.createClass({
           style={[styles.row, styles.block]}
           onPress={() => console.log('custom THW text - highlight')}>
           <Text style={styles.button}>
-            Disabled TouchableHighlight
+            Enabled TouchableHighlight
           </Text>
         </TouchableHighlight>
 


### PR DESCRIPTION
The text within an enabled TouchableHighlight was "Disabled" instead of "Enabled"
